### PR TITLE
Categorise integration tests

### DIFF
--- a/HotDocs.Sdk.ServerTest/App.config
+++ b/HotDocs.Sdk.ServerTest/App.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0"?>
 <configuration>
 	<appSettings>
-		<add key="TempPath" value="E:\GIT\hotdocs-open-sdk\SamplePortal\Files\Cache\Tmp"/>
-
 		<!-- Settings for Web Service -->
 		<add key="WebServiceEndPoint" value="BasicHttpBinding_IHDSvc"/>
 

--- a/HotDocs.Sdk.ServerTest/ServicesTest.cs
+++ b/HotDocs.Sdk.ServerTest/ServicesTest.cs
@@ -114,7 +114,7 @@ namespace HotDocs.Sdk.ServerTest
 			GetInterview(svc, logRef);
 		}
 
-		[TestMethod]
+        [TestCategory("WebServiceIntegration"), TestMethod]
 		public void GetInterview_WebService()
 		{
 			IServices svc = Util.GetWebServiceServicesInterface();
@@ -122,7 +122,7 @@ namespace HotDocs.Sdk.ServerTest
 			GetInterview(svc, logRef);
 		}
 
-		[TestMethod]
+        [TestCategory("CloudIntegration"), TestMethod]
 		public void GetInterview_Cloud()
 		{
 			IServices svc = Util.GetCloudServicesInterface();
@@ -219,7 +219,7 @@ namespace HotDocs.Sdk.ServerTest
 			AssembleDocument(svc, logRef);
 		}
 
-		[TestMethod]
+        [TestCategory("WebServiceIntegration"), TestMethod]
 		public void AssembleDocument_WebService()
 		{
 			IServices svc = Util.GetWebServiceServicesInterface();
@@ -227,7 +227,7 @@ namespace HotDocs.Sdk.ServerTest
 			AssembleDocument(svc, logRef);
 		}
 
-		[TestMethod]
+		[TestCategory("CloudIntegration"), TestMethod]
 		public void AssembleDocument_Cloud()
 		{
 			IServices svc = Util.GetCloudServicesInterface();
@@ -298,7 +298,7 @@ namespace HotDocs.Sdk.ServerTest
 			GetComponentInfo(services, logRef);
 		}
 
-		[TestMethod]
+        [TestCategory("WebServiceIntegration"), TestMethod]
 		public void GetComponentInfo_WebService()
 		{
 			IServices services = Util.GetWebServiceServicesInterface();
@@ -306,7 +306,7 @@ namespace HotDocs.Sdk.ServerTest
 			GetComponentInfo(services, logRef);
 		}
 
-		[TestMethod]
+        [TestCategory("CloudIntegration"), TestMethod]
 		public void GetComponentInfo_Cloud()
 		{
 			IServices services = Util.GetCloudServicesInterface();
@@ -357,7 +357,7 @@ namespace HotDocs.Sdk.ServerTest
 			GetAnswers(services, logRef);
 		}
 
-		[TestMethod]
+        [TestCategory("WebServiceIntegration"), TestMethod]
 		public void GetAnswers_WebService()
 		{
 			IServices services = Util.GetWebServiceServicesInterface();
@@ -365,7 +365,7 @@ namespace HotDocs.Sdk.ServerTest
 			GetAnswers(services, logRef);
 		}
 
-		[TestMethod]
+        [TestCategory("CloudIntegration"), TestMethod]
 		public void GetAnswers_Cloud()
 		{
 			IServices services = Util.GetCloudServicesInterface();
@@ -462,12 +462,12 @@ namespace HotDocs.Sdk.ServerTest
 			BuildSupportFiles(Util.GetLocalServicesInterface());
 		}
 
-		[TestMethod]
+        [TestCategory("WebServiceIntegration"), TestMethod]
 		public void BuildSupportFiles_WebService() {
 			BuildSupportFiles(Util.GetWebServiceServicesInterface());
 		}
 
-		[TestMethod]
+        [TestCategory("CloudIntegration"), TestMethod]
 		public void BuildSupportFiles_Cloud()
 		{
 			BuildSupportFiles(Util.GetCloudServicesInterface());
@@ -516,12 +516,12 @@ namespace HotDocs.Sdk.ServerTest
 			RemoveSupportFiles(Util.GetLocalServicesInterface());
 		}
 
-		[TestMethod]
+        [TestCategory("WebServiceIntegration"), TestMethod]
 		public void RemoveSupportFiles_WebService() {
 			RemoveSupportFiles(Util.GetWebServiceServicesInterface());
 		}
 
-		[TestMethod]
+        [TestCategory("CloudIntegration"), TestMethod]
 		public void RemoveSupportFiles_Cloud()
 		{
 			RemoveSupportFiles(Util.GetCloudServicesInterface());
@@ -565,13 +565,13 @@ namespace HotDocs.Sdk.ServerTest
 			GetInterviewFile(Util.GetLocalServicesInterface());
 		}
 
-		[TestMethod]
+        [TestCategory("WebServiceIntegration"), TestMethod]
 		public void GetInterviewFile_WebService()
 		{
 			GetInterviewFile(Util.GetWebServiceServicesInterface());
 		}
 
-		[TestMethod]
+        [TestCategory("CloudIntegration"), TestMethod]
 		public void GetInterviewFile_Cloud()
 		{
 			GetInterviewFile(Util.GetCloudServicesInterface());

--- a/HotDocs.Sdk.ServerTest/Util.cs
+++ b/HotDocs.Sdk.ServerTest/Util.cs
@@ -67,10 +67,7 @@ namespace HotDocs.Sdk.ServerTest
 
 		public static HotDocs.Sdk.Server.IServices GetLocalServicesInterface()
 		{
-			string tempPath = ConfigurationManager.AppSettings["TempPath"];
-			if (!Directory.Exists(tempPath))
-				Directory.CreateDirectory(tempPath);
-			return new HotDocs.Sdk.Server.Local.Services(tempPath);
+			return new HotDocs.Sdk.Server.Local.Services(Path.GetTempPath());
 		}
 
 		public static HotDocs.Sdk.Server.IServices GetWebServiceServicesInterface()


### PR DESCRIPTION
I've added categories to tests which call Web Services or Cloud Services. This makes it easy to separate them out in the Visual Studio test runner from unit tests. Helps address #18 