### PR TITLE
fixed duplicate method in WebServiceTemplateLocation

### DIFF
--- a/HotDocs.Sdk.Server/HotDocsService.cs
+++ b/HotDocs.Sdk.Server/HotDocsService.cs
@@ -24,7 +24,11 @@ namespace HotDocs.Sdk.Server
         ///     Allows connection to a HotDocs Web API
         /// </summary>
         /// <param name="hostAddress">The address of the Web API</param>
-        public HotDocsService(string hostAddress)
+        /// <param name="retrieveFromHub">
+        ///     Indicates if the template is stored in a Template Hub and if the package ID used is a
+        ///     Version ID or Template ID
+        /// </param>
+        public HotDocsService(string hostAddress, RetrieveFromHub retrieveFromHub = RetrieveFromHub.No)
         {
             if (string.IsNullOrEmpty(hostAddress))
                 throw new ArgumentException("Host address cannot be null");
@@ -32,12 +36,16 @@ namespace HotDocs.Sdk.Server
             HostAddress = hostAddress;
             SigningKey = string.Empty;
             SubscriberId = "0";
+            _retrieveFromHub = retrieveFromHub;
         }
 
         /// <summary>
         ///     Allows connection to a HotDocs Cloud Services API
         /// </summary>
-        /// <param name="retrieveFromHub"></param>
+        /// <param name="retrieveFromHub">
+        ///     Indicates if the template is stored in a Template Hub and if the package ID used is a
+        ///     Version ID or Template ID
+        /// </param>
         /// <param name="hostAddress">The address of the Cloud Services API</param>
         /// <param name="subscriberId">Your Unique SubscriberId</param>
         /// <param name="signingKey">Your Unique Signing Key</param>

--- a/HotDocs.Sdk/WebServiceTemplateLocation.cs
+++ b/HotDocs.Sdk/WebServiceTemplateLocation.cs
@@ -73,7 +73,8 @@ namespace HotDocs.Sdk
 
         public override TemplateLocation Duplicate()
         {
-            var location = new WebServiceTemplateLocation(PackageID, HostAddress) {_templateDir = _templateDir};
+            var location = new WebServiceTemplateLocation(PackageID, SubscriberId, SigningKey, RetrieveFromHub,
+                HostAddress) {_templateDir = _templateDir};
             return location;
         }
 

--- a/HotDocs.Sdk/WebServiceTemplateLocation.cs
+++ b/HotDocs.Sdk/WebServiceTemplateLocation.cs
@@ -20,13 +20,19 @@ namespace HotDocs.Sdk
         /// </summary>
         /// <param name="packageID">The Package ID of the template located in the cache of the Web API</param>
         /// <param name="hostAddress">The URI for the Web API</param>
-        public WebServiceTemplateLocation(string packageID, string hostAddress)
+        /// <param name="retrieveFromHub">
+        ///     Indicates if the template is stored in a Template Hub and if the package ID used is a
+        ///     Version ID or Template ID
+        /// </param>
+        public WebServiceTemplateLocation(string packageID, string hostAddress,
+            RetrieveFromHub retrieveFromHub = RetrieveFromHub.No)
             : base(packageID)
         {
             if (string.IsNullOrEmpty(hostAddress))
                 throw new ArgumentNullException("hostAddress");
 
             HostAddress = hostAddress;
+            RetrieveFromHub = retrieveFromHub;
 
             //Not used in Web API
             SubscriberId = "0";
@@ -64,11 +70,11 @@ namespace HotDocs.Sdk
 
         public string HostAddress { get; protected set; }
 
-        public string SubscriberId { get; set; }
+        public string SubscriberId { get; protected set; }
 
-        public string SigningKey { get; set; }
+        public string SigningKey { get; protected set; }
 
-        public RetrieveFromHub RetrieveFromHub { get; set; }
+        public RetrieveFromHub RetrieveFromHub { get; protected set; }
 
 
         public override TemplateLocation Duplicate()


### PR DESCRIPTION
This method was not copying all of the required data. Fixed it so it does duplicate the location completely now.